### PR TITLE
Feat : 관심전략 기능 추가

### DIFF
--- a/src/main/java/com/sysmatic2/finalbe/attachment/service/FileService.java
+++ b/src/main/java/com/sysmatic2/finalbe/attachment/service/FileService.java
@@ -23,7 +23,7 @@ public class FileService {
      * 파일 업로드
      */
     @Transactional
-    public FileMetadataDto uploadFile(MultipartFile file, String uploaderId, String category, String fileCategoryItemId, String displayName) {
+    public FileMetadataDto uploadFile(MultipartFile file, String uploaderId, String category, String fileCategoryItemId) {
         // 1. 파일 검증
         FileValidator.validateFile(file, category);
 
@@ -46,16 +46,11 @@ public class FileService {
             metadata.setFileName(uniqueFileName);
             metadata.setFilePath(fileUrl);
             metadata.setFileSize(file.getSize());
+            metadata.setDisplayName(file.getOriginalFilename());
             metadata.setContentType(file.getContentType());
             metadata.setFileCategory(category);
             metadata.setUploaderId(uploaderId);
 
-            // 실계좌인증인 경우, 전달받은 displayName 사용
-            if("liveaccount".equals(category)) {
-                metadata.setDisplayName(displayName);
-            } else {
-                metadata.setDisplayName(file.getOriginalFilename());
-            }
 
             // 카테고리 아이템 Id가 있는 경우,
             if (fileCategoryItemId != null) {

--- a/src/main/java/com/sysmatic2/finalbe/attachment/service/IconService.java
+++ b/src/main/java/com/sysmatic2/finalbe/attachment/service/IconService.java
@@ -26,7 +26,7 @@ public class IconService {
         String uploaderId = "admin";
 
         // 새로운 아이콘 등록
-        return fileService.uploadFile(file, uploaderId, category, null, category);
+        return fileService.uploadFile(file, uploaderId, category, null);
     }
 
     /**

--- a/src/main/java/com/sysmatic2/finalbe/attachment/service/ProfileService.java
+++ b/src/main/java/com/sysmatic2/finalbe/attachment/service/ProfileService.java
@@ -36,7 +36,7 @@ public class ProfileService {
             return fileMetadataDto;
         } else {
             // 새로운 파일 업로드
-            FileMetadataDto fileMetadataDto = fileService.uploadFile(file, uploaderId, category, null, category);
+            FileMetadataDto fileMetadataDto = fileService.uploadFile(file, uploaderId, category, null);
 
             // 회원 정보의 fileId 업데이트
             memberHelper.initMemberFileId(uploaderId, fileMetadataDto.getId().toString(), fileMetadataDto.getFilePath());

--- a/src/main/java/com/sysmatic2/finalbe/attachment/service/ProposalService.java
+++ b/src/main/java/com/sysmatic2/finalbe/attachment/service/ProposalService.java
@@ -26,7 +26,7 @@ public class ProposalService {
         String category = "proposal";
 
         // 새로운 제안서 등록
-        return fileService.uploadFile(file, uploaderId, category, null, category);
+        return fileService.uploadFile(file, uploaderId, category, null);
     }
 
     /**

--- a/src/main/java/com/sysmatic2/finalbe/cs/dto/ConsultationCreateDto.java
+++ b/src/main/java/com/sysmatic2/finalbe/cs/dto/ConsultationCreateDto.java
@@ -48,5 +48,6 @@ public class ConsultationCreateDto {
   private String content;
 
   @NotNull(message = "상담 상태는 필수입니다.")
-  private ConsultationStatus status;
+  @Builder.Default
+  private ConsultationStatus status = ConsultationStatus.PENDING; // 기본값 설정
 }

--- a/src/main/java/com/sysmatic2/finalbe/cs/dto/ConsultationDetailResponseDto.java
+++ b/src/main/java/com/sysmatic2/finalbe/cs/dto/ConsultationDetailResponseDto.java
@@ -1,46 +1,46 @@
-package com.sysmatic2.finalbe.cs.dto;
+  package com.sysmatic2.finalbe.cs.dto;
 
-import com.sysmatic2.finalbe.cs.entity.ConsultationStatus;
-import java.math.BigDecimal;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+  import com.sysmatic2.finalbe.cs.entity.ConsultationStatus;
+  import java.math.BigDecimal;
+  import lombok.AllArgsConstructor;
+  import lombok.Builder;
+  import lombok.Data;
+  import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
+  import java.time.LocalDateTime;
 
-/**
- * 상담 상세 응답 DTO
- */
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
-public class ConsultationDetailResponseDto {
-  private Long id;
-  private String investorId;
-  private String investorName;
-  private String investorProfileUrl; // 추가
-  private String traderId;
-  private String traderName;
-  private String traderProfileUrl; // 추가
+  /**
+   * 상담 상세 응답 DTO
+   */
+  @Data
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Builder
+  public class ConsultationDetailResponseDto {
+    private Long id;
+    private String investorId;
+    private String investorName;
+    private String investorProfileUrl; // 추가
+    private String traderId;
+    private String traderName;
+    private String traderProfileUrl; // 추가
 
-  private Long strategyId; // 전략 ID 포함
-  private String strategyName; // 전략 이름 포함
+    private Long strategyId; // 전략 ID 포함
+    private String strategyName; // 전략 이름 포함
 
-  private BigDecimal investmentAmount;
-  private LocalDateTime investmentDate;
-  private String title;
-  private String content;
-  private ConsultationStatus status;
-  private LocalDateTime createdAt;
-  private LocalDateTime updatedAt;
+    private BigDecimal investmentAmount;
+    private LocalDateTime investmentDate;
+    private String title;
+    private String content;
+    private ConsultationStatus status;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
 
-  // 추가된 필드: 트레이더의 답변 내용 및 답변 날짜
-  private String replyContent;
-  private LocalDateTime answerDate;
+    // 추가된 필드: 트레이더의 답변 내용 및 답변 날짜
+    private String replyContent;
+    private LocalDateTime answerDate;
 
-  // 추가된 필드: 답변 생성일 및 수정일
-  private LocalDateTime replyCreatedAt;
-  private LocalDateTime replyUpdatedAt;
-}
+    // 추가된 필드: 답변 생성일 및 수정일
+    private LocalDateTime replyCreatedAt;
+    private LocalDateTime replyUpdatedAt;
+  }

--- a/src/main/java/com/sysmatic2/finalbe/cs/mapper/ConsultationMapper.java
+++ b/src/main/java/com/sysmatic2/finalbe/cs/mapper/ConsultationMapper.java
@@ -44,12 +44,12 @@ public class ConsultationMapper {
   public ConsultationDetailResponseDto toDetailResponseDto(ConsultationEntity entity) {
     return ConsultationDetailResponseDto.builder()
             .id(entity.getId())
-            .investorId(entity.getInvestor().getMemberId())
-            .investorName(entity.getInvestor().getNickname())
-            .traderId(entity.getTrader().getMemberId())
-            .traderName(entity.getTrader().getNickname())
-            .strategyId(entity.getStrategy().getStrategyId())
-            .strategyName(entity.getStrategy().getStrategyTitle())
+            .investorId(entity.getInvestor() == null ? null : entity.getInvestor().getMemberId())
+            .investorName(entity.getInvestor() == null ? "탈퇴한 사용자" : entity.getInvestor().getNickname())
+            .traderId(entity.getTrader() == null ? null : entity.getTrader().getMemberId())
+            .traderName(entity.getTrader() == null ? "탈퇴한 사용자" : entity.getTrader().getNickname())
+            .strategyId(entity.getStrategy() == null ? null : entity.getStrategy().getStrategyId())
+            .strategyName(entity.getStrategy() == null ? "전략 정보 없음" : entity.getStrategy().getStrategyTitle())
             .investmentAmount(entity.getInvestmentAmount())
             .investmentDate(entity.getInvestmentDate())
             .title(entity.getTitle())
@@ -61,6 +61,8 @@ public class ConsultationMapper {
             .answerDate(entity.getAnswerDate())
             .replyCreatedAt(entity.getReplyCreatedAt())
             .replyUpdatedAt(entity.getReplyUpdatedAt())
+            .investorProfileUrl(entity.getInvestor() == null ? null : entity.getInvestor().getProfilePath())
+            .traderProfileUrl(entity.getTrader() == null ? null : entity.getTrader().getProfilePath())
             .build();
   }
 
@@ -70,13 +72,15 @@ public class ConsultationMapper {
   public ConsultationListResponseDto toListResponseDto(ConsultationEntity entity) {
     return ConsultationListResponseDto.builder()
             .id(entity.getId())
-            .investorName(entity.getInvestor().getNickname())
-            .traderName(entity.getTrader().getNickname())
-            .strategyName(entity.getStrategy().getStrategyTitle())
+            .investorName(entity.getInvestor() == null ? "탈퇴한 사용자" : entity.getInvestor().getNickname())
+            .traderName(entity.getTrader() == null ? "탈퇴한 사용자" : entity.getTrader().getNickname())
+            .strategyName(entity.getStrategy() == null ? "전략 정보 없음" : entity.getStrategy().getStrategyTitle())
             .investmentDate(entity.getInvestmentDate())
             .title(entity.getTitle())
             .status(entity.getStatus())
             .createdAt(entity.getCreatedAt())
+            .investorProfileUrl(entity.getInvestor() == null ? null : entity.getInvestor().getProfilePath())
+            .traderProfileUrl(entity.getTrader() == null ? null : entity.getTrader().getProfilePath())
             .build();
   }
 

--- a/src/main/java/com/sysmatic2/finalbe/exception/DuplicateFollowingStrategyException.java
+++ b/src/main/java/com/sysmatic2/finalbe/exception/DuplicateFollowingStrategyException.java
@@ -1,0 +1,6 @@
+package com.sysmatic2.finalbe.exception;
+
+public class DuplicateFollowingStrategyException extends RuntimeException{
+    public DuplicateFollowingStrategyException(String message) { super(message);
+    }
+}

--- a/src/main/java/com/sysmatic2/finalbe/member/controller/FollowingStrategyController.java
+++ b/src/main/java/com/sysmatic2/finalbe/member/controller/FollowingStrategyController.java
@@ -1,0 +1,90 @@
+package com.sysmatic2.finalbe.member.controller;
+
+import com.sysmatic2.finalbe.member.dto.*;
+import com.sysmatic2.finalbe.member.entity.FollowingStrategyEntity;
+import com.sysmatic2.finalbe.member.entity.FollowingStrategyFolderEntity;
+import com.sysmatic2.finalbe.member.repository.MemberRepository;
+import com.sysmatic2.finalbe.member.service.FollowingStrategyService;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/members")
+@RequiredArgsConstructor
+
+public class FollowingStrategyController {
+    private final FollowingStrategyService followingStrategyService;
+    private final MemberRepository memberRepository;
+
+    //관심 전략 등록
+    @PostMapping("/following-strategy")
+    public ResponseEntity<Map<String,Object>> createFollwingStrategy(@RequestBody FollowingStrategyRequestDto followingStrategyDto,
+                                                                     @AuthenticationPrincipal CustomUserDetails customUserDetails){
+        FollowingStrategyResponseDto responseDto = followingStrategyService.createFollowingStrategy(followingStrategyDto,customUserDetails);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(Map.of(
+                "message","관심전략이 정상적으로 등록되었습니다.",
+                "data",responseDto
+        ));
+    }
+
+    //관심 전략 목록 조회
+    @GetMapping("/follwing-strategy/list/{folderId}")
+    public ResponseEntity<Map<String,Object>> getListFollowingStrategy(@PathVariable Long folderId, FollowingStrategyRequestDto followingStrategyRequestDto, @AuthenticationPrincipal CustomUserDetails customUserDetails){
+        //ArrayList<FollowingStrategyListDto> list = followingStrategyService.getListFollowingStrategy(followingStrategyRequestDto, customUserDetails);
+
+        List<FollowingStrategyListDto> list = followingStrategyService.getListFollowingStrategy1(folderId);
+
+        return ResponseEntity.status(HttpStatus.OK).body(Map.of(
+                "message","관심전략 목록이 정상적으로 조회되었습니다.",
+                "data", list
+        ));
+    }
+    //관심 전략 목록 조회(페이징처리)
+    @GetMapping("/follwing-strategy/page/{folderId}")
+    public ResponseEntity<Map<String,Object>> getListFollowingStrategyPage(@PathVariable Long folderId, FollowingStrategyRequestDto followingStrategyRequestDto, @AuthenticationPrincipal CustomUserDetails customUserDetails, Pageable pageable){
+
+        Page<FollowingStrategyListDto> page  = followingStrategyService.getListFollowingStrategyPage(pageable,10,folderId);
+
+        return ResponseEntity.status(HttpStatus.OK).body(Map.of(
+                "message","관심전략 목록이 정상적으로 조회되었습니다.",
+                "data", page.getContent(),       // 페이징된 데이터
+                "currentPage", page.getNumber(), // 현재 페이지
+                "totalItems", page.getTotalElements(), // 전체 데이터 수
+                "totalPages", page.getTotalPages() // 전체 페이지 수
+        ));
+    }
+
+
+    //관심 전략 삭제
+    @DeleteMapping("/follwing-strategy/{followingStrategyId}")
+    public ResponseEntity<Map<String,String>> deleteFollowingStrategy(@PathVariable Long followingStrategyId, FollowingStrategyRequestDto followingStrategyRequestDto, @AuthenticationPrincipal CustomUserDetails customUserDetails){
+        followingStrategyService.deleteFollowingStrategy(followingStrategyRequestDto,customUserDetails);
+        return ResponseEntity.status(HttpStatus.OK).body(Map.of(
+                "message","관심전략이 정상적으로 삭제되었습니다."
+        ));
+    }
+
+    //관심 전략 이동
+
+    //관심전략폴더ID별 관심 전략 갯수 count
+    @GetMapping("/follwing-strategy/{folderId}")
+    public ResponseEntity<Map<String,Object>> getCountFollowingStrategy(@PathVariable Long folderId, FollowingStrategyRequestDto followingStrategyRequestDto, @AuthenticationPrincipal CustomUserDetails customUserDetails){
+        int count = followingStrategyService.countFollowingStrategy(folderId);
+        return ResponseEntity.status(HttpStatus.CREATED).body(Map.of(
+                "message","정상적으로 조회 성공했습니다.",
+                "count",count
+        ));
+    }
+
+}

--- a/src/main/java/com/sysmatic2/finalbe/member/controller/MemberController.java
+++ b/src/main/java/com/sysmatic2/finalbe/member/controller/MemberController.java
@@ -34,7 +34,7 @@ public class MemberController {
 
     //로그인
     @PostMapping("/login")
-    public String login(HttpServletRequest request) {
+    public String login(HttpServletRequest request, @RequestBody LoginDTO LoginDto) {
         return "login";
     }
     //로그아웃

--- a/src/main/java/com/sysmatic2/finalbe/member/dto/FollowingStrategyListDto.java
+++ b/src/main/java/com/sysmatic2/finalbe/member/dto/FollowingStrategyListDto.java
@@ -1,0 +1,37 @@
+package com.sysmatic2.finalbe.member.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class FollowingStrategyListDto {
+    private Long followingStrategyId;
+    private Long strategyId;
+    private BigDecimal kp_ratio;
+    //SM-Score
+    private BigDecimal smScore;
+    private String strategyTitle;
+
+    //팔로워수
+    private Long followersCount;
+
+    //순위
+    //분석그래프
+    //수익률
+    //MDD
+
+    public FollowingStrategyListDto(Long followingStrategyId, Long strategyId, Long followersCount, BigDecimal kp_ratio, BigDecimal smScore, String strategyTitle) {
+        this.followingStrategyId = followingStrategyId;
+        this.strategyId = strategyId;
+        this.followersCount = followersCount;
+        this.kp_ratio = kp_ratio;
+        this.smScore = smScore;
+        this.strategyTitle = strategyTitle;
+    }
+}

--- a/src/main/java/com/sysmatic2/finalbe/member/dto/FollowingStrategyRequestDto.java
+++ b/src/main/java/com/sysmatic2/finalbe/member/dto/FollowingStrategyRequestDto.java
@@ -1,0 +1,12 @@
+package com.sysmatic2.finalbe.member.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class FollowingStrategyRequestDto {
+    private Long folderId;
+    private Long strategyId;
+    private Long followingStrategyId;
+}

--- a/src/main/java/com/sysmatic2/finalbe/member/dto/FollowingStrategyResponseDto.java
+++ b/src/main/java/com/sysmatic2/finalbe/member/dto/FollowingStrategyResponseDto.java
@@ -1,0 +1,15 @@
+package com.sysmatic2.finalbe.member.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class FollowingStrategyResponseDto {
+    private Long folderId;
+    private Long strategyId;
+    private Long followingStrategyId;
+    private String strategyName;
+}

--- a/src/main/java/com/sysmatic2/finalbe/member/entity/FollowingStrategyEntity.java
+++ b/src/main/java/com/sysmatic2/finalbe/member/entity/FollowingStrategyEntity.java
@@ -4,6 +4,7 @@ import com.sysmatic2.finalbe.common.Auditable;
 import com.sysmatic2.finalbe.strategy.entity.StrategyEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 
@@ -14,6 +15,7 @@ import java.time.LocalDateTime;
 @Getter
 @Setter
 @ToString
+@NoArgsConstructor
 public class FollowingStrategyEntity extends Auditable {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -34,4 +36,12 @@ public class FollowingStrategyEntity extends Auditable {
 
     @Column(name = "followed_at", nullable = false)
     private LocalDateTime followedAt;
+
+    public FollowingStrategyEntity(FollowingStrategyFolderEntity followingStrategyFolder, MemberEntity member, StrategyEntity strategy, LocalDateTime followedAt) {
+
+        this.followingStrategyFolder = followingStrategyFolder;
+        this.member = member;
+        this.strategy = strategy;
+        this.followedAt = followedAt;
+    }
 }

--- a/src/main/java/com/sysmatic2/finalbe/member/repository/FollowingStrategyRepository.java
+++ b/src/main/java/com/sysmatic2/finalbe/member/repository/FollowingStrategyRepository.java
@@ -1,9 +1,51 @@
 package com.sysmatic2.finalbe.member.repository;
 
+import com.sysmatic2.finalbe.member.dto.FollowingStrategyListDto;
 import com.sysmatic2.finalbe.member.entity.FollowingStrategyEntity;
+import com.sysmatic2.finalbe.member.entity.FollowingStrategyFolderEntity;
 import com.sysmatic2.finalbe.strategy.entity.StrategyEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface FollowingStrategyRepository extends JpaRepository<FollowingStrategyEntity, Long> {
     void deleteAllByStrategy(StrategyEntity strategy);
+    FollowingStrategyEntity findByFollowingStrategyFolderAndStrategy(FollowingStrategyFolderEntity followingStrategyFolder, StrategyEntity strategy);
+    int deleteByFollowingStrategyId(Long followingStrategyId);
+    boolean existsByFollowingStrategyId(Long followingStrategyId);
+
+    int countByFollowingStrategyFolder(FollowingStrategyFolderEntity followingStrategyFolder);
+
+    //Page<FollowingStrategyListDto> findAllAsFollowingStrategyListDto(Pageable pageable);
+
+    //Page<FollowingStrategyEntity> findByStats(String stats, Pageable pageable);
+
+    //관심전략폴더ID에 등록된 전략ID의 리스트 정보를 조회
+
+//        @Query("SELECT new com.sysmatic2.finalbe.member.dto.FollowingStrategyListDto("
+//                +"f.followingStrategyId, s.followers_count, s.kp_ratio, s.smScore, s.StrategyTitle) " +
+//                "FROM FollowingStrategyEntity f, StrategyEntity s"+
+//                "WHERE f.StrategyEntity = s.StrategyEntity"+
+//                "AND f.followingStrategyFolder =:follwingStrategyFolder")
+
+    @Query("SELECT new com.sysmatic2.finalbe.member.dto.FollowingStrategyListDto(" +
+            "f.followingStrategyId, s.strategyId, s.followersCount, s.kpRatio, s.smScore, s.strategyTitle) " +
+            "FROM FollowingStrategyEntity f " +
+            "JOIN f.strategy s " +
+            "WHERE f.followingStrategyFolder = :followingStrategyFolder AND s.isPosted = 'y' " +
+            "AND s.isApproved = 'y'")
+    List<FollowingStrategyListDto> getListFollowingStrategy1(@Param("followingStrategyFolder") FollowingStrategyFolderEntity followingStrategyFolder);
+
+    @Query("SELECT new com.sysmatic2.finalbe.member.dto.FollowingStrategyListDto(" +
+            "f.followingStrategyId, s.strategyId, s.followersCount, s.kpRatio, s.smScore, s.strategyTitle) " +
+            "FROM FollowingStrategyEntity f " +
+            "JOIN f.strategy s " +
+            "WHERE f.followingStrategyFolder = :followingStrategyFolder AND s.isPosted = 'y' " +
+            "AND s.isApproved = 'y'")
+    Page<FollowingStrategyListDto> getListFollowingStrategyPage(@Param("followingStrategyFolder") FollowingStrategyFolderEntity followingStrategyFolder, Pageable pageable);
+
 }

--- a/src/main/java/com/sysmatic2/finalbe/member/service/FollowingStrategyService.java
+++ b/src/main/java/com/sysmatic2/finalbe/member/service/FollowingStrategyService.java
@@ -1,0 +1,133 @@
+package com.sysmatic2.finalbe.member.service;
+
+import com.sysmatic2.finalbe.exception.DuplicateFollowingStrategyException;
+import com.sysmatic2.finalbe.member.dto.CustomUserDetails;
+import com.sysmatic2.finalbe.member.dto.FollowingStrategyListDto;
+import com.sysmatic2.finalbe.member.dto.FollowingStrategyRequestDto;
+import com.sysmatic2.finalbe.member.dto.FollowingStrategyResponseDto;
+import com.sysmatic2.finalbe.member.entity.FollowingStrategyEntity;
+import com.sysmatic2.finalbe.member.entity.FollowingStrategyFolderEntity;
+import com.sysmatic2.finalbe.member.entity.MemberEntity;
+import com.sysmatic2.finalbe.member.repository.FollowingStrategyFolderRepository;
+import com.sysmatic2.finalbe.member.repository.FollowingStrategyRepository;
+import com.sysmatic2.finalbe.strategy.entity.StrategyEntity;
+import com.sysmatic2.finalbe.strategy.repository.StrategyRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class FollowingStrategyService {
+    private final FollowingStrategyRepository followingStrategyRepository;
+    private final StrategyRepository strategyRepository;
+    private final FollowingStrategyFolderRepository followingStrategyFolderRepository;
+
+    //폴더별 관심전략 목록 조회 서비스
+    public List<FollowingStrategyListDto> getListFollowingStrategy1(Long folderId){
+//        FollowingStrategyListDto listDto = new FollowingStrategyListDto();
+//        listDto.setStrategyName();//전략이름
+//        listDto.setFollowers_count();
+//        listDto.setSmScore();
+//        listDto.setFollowingStrategyId();
+//        listDto.setStrategyId();
+
+       // ArrayList<FollowingStrategyListDto> list = new ArrayList<>();
+        //폴더엔티티를 던져줘야해?
+        FollowingStrategyFolderEntity folderEntity = followingStrategyFolderRepository.findById(folderId).get();
+        List<FollowingStrategyListDto> list = followingStrategyRepository.getListFollowingStrategy1(folderEntity);
+
+        return list;
+    }
+
+    //폴더별 관심전략 목록 조회 페이징
+    public Page<FollowingStrategyListDto> getListFollowingStrategyPage(Pageable pageable,int size,Long folderId){
+        //Pageable pageable = PageRequest.of(page, size);
+        FollowingStrategyFolderEntity folderEntity = followingStrategyFolderRepository.findById(folderId).get();
+        return followingStrategyRepository.getListFollowingStrategyPage(folderEntity,pageable);
+    }
+
+//    public Page<FollowingStrategyEntity> getEntitesByStatus(String status,int page,int size){
+//        Pageable pageable = PageRequest.of(page, size);
+//        return followingStrategyRepository.findByStats(status,pageable);
+//    }
+
+    //폴더ID 별 등록된 관심전략 폴더 Count 조회
+    public int countFollowingStrategy(long folderId) {
+        FollowingStrategyFolderEntity folderEntity = followingStrategyFolderRepository.findById(folderId).get();
+        return followingStrategyRepository.countByFollowingStrategyFolder(folderEntity);
+    }
+
+    //관심 전략 등록 서비스
+    @Transactional
+    public FollowingStrategyResponseDto createFollowingStrategy(FollowingStrategyRequestDto requestDto, CustomUserDetails customUserDetails){
+        FollowingStrategyResponseDto ResponseDto = new FollowingStrategyResponseDto();
+        StrategyEntity strategyEntity = strategyRepository.findById(requestDto.getStrategyId())
+                .orElseThrow(() -> new IllegalArgumentException("해당 ID의 전략이 존재하지 않습니다."));
+        FollowingStrategyFolderEntity followingStrategyFolderEntity = followingStrategyFolderRepository.findById(requestDto.getFolderId())
+                .orElseThrow(()-> new IllegalArgumentException("해당 ID의 폴더가 존재하지 않습니다."));
+        //이미 등록된 관심전략 체크하는 로직 추가 필요
+        //선택한 종목이 해당 관심 전략에 이미 등록되어 있습니다.
+        //폴더에 해당 전략id가 있는지 체크
+        FollowingStrategyEntity folllowingStrategeyEntity = followingStrategyRepository.findByFollowingStrategyFolderAndStrategy(followingStrategyFolderEntity,strategyEntity);
+
+        if(folllowingStrategeyEntity != null){
+               throw new DuplicateFollowingStrategyException("선택한 종목이 해당 관심 전략폴더에 이미 등록되어 있습니다.");
+        }
+
+       MemberEntity member = customUserDetails.getMemberEntity();
+        if (member == null) {
+            throw new IllegalStateException("회원 정보가 없습니다.");
+        }
+
+        LocalDateTime followedAt = LocalDateTime.now();
+
+        FollowingStrategyEntity followingStrategyEntity = new FollowingStrategyEntity(
+                followingStrategyFolderEntity,member,strategyEntity,followedAt);
+        followingStrategyRepository.save(followingStrategyEntity);
+
+        //관심전략 등록하면 전략의 follower_count 수 증가해줘야함
+        strategyEntity.incrementFollowersCount();
+        strategyRepository.save(strategyEntity);
+
+        ResponseDto.setFolderId(requestDto.getFolderId());
+        ResponseDto.setStrategyId(requestDto.getStrategyId());
+        ResponseDto.setFollowingStrategyId(followingStrategyEntity.getFollowingStrategyId());
+        ResponseDto.setStrategyName(strategyEntity.getStrategyTitle());
+
+        return ResponseDto;
+    }
+
+    //관심 전략 삭제
+    @Transactional
+    public void deleteFollowingStrategy(FollowingStrategyRequestDto requestDto, CustomUserDetails customUserDetails){
+        //삭제할 관심전략 조회
+        Optional<FollowingStrategyEntity> followingStrategyEntityOptional = followingStrategyRepository.findById(requestDto.getFollowingStrategyId());
+
+        if(followingStrategyEntityOptional.isEmpty()){
+            throw new IllegalStateException("삭제할 관심전략이 존재하지 않습니다. 관심전략ID:" + requestDto.getFollowingStrategyId());
+        }
+        FollowingStrategyEntity followingStrategyEntity = followingStrategyEntityOptional.get();
+        StrategyEntity strategyEntity = followingStrategyEntity.getStrategy();
+        if(!followingStrategyEntity.getCreatedBy().equals(customUserDetails.getMemberId())){
+            throw new IllegalStateException("해당 관심전략을 삭제 권한이 없습니다. 관심전략ID:" + requestDto.getFollowingStrategyId());
+        }
+
+        int resultCnt = followingStrategyRepository.deleteByFollowingStrategyId(requestDto.getFollowingStrategyId());
+
+        if(resultCnt == 0){
+            throw new IllegalStateException("삭제할 전략 ID가 존재하지 않습니다. 관심전략ID:" + requestDto.getFollowingStrategyId());
+        }
+
+        //관심전략 삭제하면 전략의 follower_count 수 감소시켜줘야함
+        strategyEntity.decrementFollowersCount();
+        strategyRepository.save(strategyEntity);
+    }
+
+}

--- a/src/main/java/com/sysmatic2/finalbe/strategy/controller/LiveAccountDataController.java
+++ b/src/main/java/com/sysmatic2/finalbe/strategy/controller/LiveAccountDataController.java
@@ -28,7 +28,6 @@ public class LiveAccountDataController {
      *
      * @param file         등록할 이미지 파일
      * @param strategyId   전략 ID
-     * @param displayName  파일 이름 (등록 날짜 형식: yyyy.MM.dd)
      * @param userDetails   업로더 ID (JWT 또는 인증정보에서 추출)
      * @return 등록된 실계좌 이미지 정보
      */
@@ -36,11 +35,10 @@ public class LiveAccountDataController {
     public ResponseEntity<LiveAccountDataResponseDto> uploadLiveAccountData(
             @RequestParam("file") MultipartFile file,
             @PathVariable Long strategyId,
-            @RequestParam String displayName,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
 
         // 서비스 호출
-        LiveAccountDataResponseDto response = liveAccountDataService.uploadLiveAccountData(file, userDetails.getMemberId(), strategyId, displayName);
+        LiveAccountDataResponseDto response = liveAccountDataService.uploadLiveAccountData(file, userDetails.getMemberId(), strategyId);
 
         // 응답 반환
         return ResponseEntity.status(HttpStatus.CREATED).body(response);

--- a/src/main/java/com/sysmatic2/finalbe/strategy/controller/LiveAccountDataController.java
+++ b/src/main/java/com/sysmatic2/finalbe/strategy/controller/LiveAccountDataController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @RestController
@@ -75,18 +76,18 @@ public class LiveAccountDataController {
      * @param liveAccountId pagenation에 page 값(default = 0)
      * @return 삭제 완료 메시지
      */
-    @DeleteMapping("/{liveAccountId}")
-    public ResponseEntity<Map<String, String>> deleteLiveAccountData(
-            @RequestParam Long strategyId,
-            @PathVariable Long liveAccountId){
+    @DeleteMapping("/{strategyId}")
+    public ResponseEntity<Map<String, Object>> deleteLiveAccountData(
+            @PathVariable Long strategyId,
+            @RequestBody List<Long> liveAccountId){
 
         // 실계좌 인증 삭제
-        liveAccountDataService.deleteLiveAccountData(strategyId, liveAccountId);
+        liveAccountDataService.deleteLiveAccountDataList(strategyId, liveAccountId);
 
         // 응답 반환
-        Map<String, String> response = new HashMap<>();
+        Map<String, Object> response = new HashMap<>();
         response.put("message", "Live account data successfully deleted.");
-        response.put("liveAccountId", liveAccountId.toString());
+        response.put("deletedIds", liveAccountId);
         response.put("strategyId", strategyId.toString());
 
         return ResponseEntity.ok(response);

--- a/src/main/java/com/sysmatic2/finalbe/strategy/entity/StrategyEntity.java
+++ b/src/main/java/com/sysmatic2/finalbe/strategy/entity/StrategyEntity.java
@@ -90,4 +90,15 @@ public class StrategyEntity extends Auditable {
     //전략(1) : 관계(N)
     @OneToMany(mappedBy = "strategyEntity", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<StrategyIACEntity> strategyIACEntities;
+
+    public void incrementFollowersCount() {
+        this.followersCount++;
+    }
+
+    // 팔로우 감소 (followersCount가 음수가 되지 않도록 보호)
+    public void decrementFollowersCount() {
+        if (this.followersCount > 0) {
+            this.followersCount--;
+        }
+    }
 }

--- a/src/main/java/com/sysmatic2/finalbe/strategy/repository/LiveAccountDataRepository.java
+++ b/src/main/java/com/sysmatic2/finalbe/strategy/repository/LiveAccountDataRepository.java
@@ -11,4 +11,5 @@ import java.util.List;
 public interface LiveAccountDataRepository extends JpaRepository<LiveAccountDataEntity, Long> {
     Page<LiveAccountDataEntity> findAllByStrategy(StrategyEntity strategy, Pageable pageable);
     List<LiveAccountDataEntity> findAllByStrategy(StrategyEntity strategy);
+    List<LiveAccountDataEntity> findAllByLiveAccountIdInAndStrategy(List<Long> ids, StrategyEntity strategy);
 }

--- a/src/main/java/com/sysmatic2/finalbe/strategy/service/LiveAccountDataService.java
+++ b/src/main/java/com/sysmatic2/finalbe/strategy/service/LiveAccountDataService.java
@@ -42,17 +42,16 @@ public class LiveAccountDataService {
      * @param file          등록할 실계좌 이미지 파일
      * @param uploaderId    업로더 ID
      * @param strategyId    전략 ID (실계좌 인증이 속하는 전략 ID)
-     * @param displayName   파일 이름 (실계좌 인증 날짜 ex. 2024.01.01)
      *
      * @return 해당 전략에 속한 실계좌 이미지 정보를 포함한 LiveAccountDataResponseDto
      */
     @Transactional
-    public LiveAccountDataResponseDto uploadLiveAccountData(MultipartFile file, String uploaderId, Long strategyId, String displayName) {
+    public LiveAccountDataResponseDto uploadLiveAccountData(MultipartFile file, String uploaderId, Long strategyId) {
         String category = "liveaccount";
 
         // 1. Validation
         // displayName (2024.01.01 인지 확인)
-        validateDateFormat(displayName);
+        //validateDateFormat(displayName);
 
         // strategy가 유효한 전략인지 확인하고 조회
         validateStrategy(strategyId);
@@ -60,12 +59,12 @@ public class LiveAccountDataService {
                 .orElseThrow(() -> new StrategyNotFoundException("Strategy not found with ID: " + strategyId + "in live account data uploading."));
 
         // 2. s3에 이미지 파일 업로드 및 FileMetadata 데이터
-        FileMetadataDto fileMetadataDto = fileService.uploadFile(file, uploaderId, category, strategyId.toString(), displayName);
+        FileMetadataDto fileMetadataDto = fileService.uploadFile(file, uploaderId, category, strategyId.toString());
 
         // 3. LiveAccountData 데이터 등록
         LiveAccountDataEntity liveAccountDataEntity = new LiveAccountDataEntity();
         liveAccountDataEntity.setStrategy(strategyEntity);
-        liveAccountDataEntity.setFileName(displayName);
+        liveAccountDataEntity.setFileName(fileMetadataDto.getDisplayName());
         liveAccountDataEntity.setFileLink(fileMetadataDto.getFilePath());
         liveAccountDataEntity.setFileSize(fileMetadataDto.getFileSize());
         liveAccountDataEntity.setFileType(fileMetadataDto.getContentType());


### PR DESCRIPTION
**바로 머지하지 마세요! 검토 후 머지해야합니다!**

## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [X] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 
Feat : 관심전략 기능 추가
<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1.FollowingStrategyRepository 
-관심전략 목록조회(페이징)
-관심전략 삭제(관심전략ID)
-관심전략 count조회(폴더별)
-관심전략 등록 확인

2.FollowingStrategyEntity
-생성자 추가

3.FollowingStrategyService
-관심전략 등록
-관심전략 목록 조회
-관심전략 목록 조회(페이징)
-관심전략 삭제
-관심전략 폴더ID별 관심전략 갯수 Count

4.FollowingStrategyController
-관심전략 등록
-관심전략 목록 조회
-관심전략 목록 조회(페이징)
-관심전략 삭제
-관심전략 폴더ID별 관심전략 갯수 Count

5..관심전략에서 사용할 Dto 추가
-FollowingStrategyRequestDto
-FollowingStrategyResponseDto
-FollowingStrategyListDto

6.관심전략 예외처리
-DuplicateFollowingStrategyException
<br />

## :: 쓰이는 모듈
<br />

## :: 기타 질문 및 특이 사항

