### PR TITLE
Fix : 관심전략 기능 수정

### DIFF
--- a/src/main/java/com/sysmatic2/finalbe/admin/repository/StrategyApprovalRequestsRepository.java
+++ b/src/main/java/com/sysmatic2/finalbe/admin/repository/StrategyApprovalRequestsRepository.java
@@ -17,6 +17,11 @@ public interface StrategyApprovalRequestsRepository extends JpaRepository<Strate
     //Pagination 적용한 리스트
     Page<StrategyApprovalRequestsEntity> findAll(Pageable pageable);
 
+    //Pagination 적용, 승인, 승인대기인 요청만 가져오도록
+    Page<StrategyApprovalRequestsEntity> findByIsApprovedIn(List<String> isApprovedList, Pageable pageable);
+
+
+
     //전략 id값으로 해당 객체 가져오기
     @Query("SELECT requestEntity FROM StrategyApprovalRequestsEntity requestEntity " +
             "WHERE requestEntity.strategy.strategyId = :strategyId AND requestEntity.isApproved = 'N'")

--- a/src/main/java/com/sysmatic2/finalbe/admin/service/StrategyApprovalRequestsService.java
+++ b/src/main/java/com/sysmatic2/finalbe/admin/service/StrategyApprovalRequestsService.java
@@ -42,7 +42,8 @@ public class StrategyApprovalRequestsService {
         Pageable pageable = PageRequest.of(page, size, Sort.by("requestDatetime").descending());
 
         //페이지 객체를 넣고 요청 엔티티 목록을 가져온다.
-        Page<StrategyApprovalRequestsEntity> requestsEntityPage = strategyApprovalRequestsRepository.findAll(pageable);
+        List<String> isApprovedList = Arrays.asList("Y", "P"); //승인, 승인대기인 것만
+        Page<StrategyApprovalRequestsEntity> requestsEntityPage = strategyApprovalRequestsRepository.findByIsApprovedIn(isApprovedList, pageable);
 
         //엔티티 목록을 dto목록으로 변환한다.
         Page<ApprovalRequestResponseDto> requestResponseDtos = requestsEntityPage.map(DtoEntityConversion::convertToApprovalDto);

--- a/src/main/java/com/sysmatic2/finalbe/member/controller/FollowingStrategyController.java
+++ b/src/main/java/com/sysmatic2/finalbe/member/controller/FollowingStrategyController.java
@@ -1,11 +1,9 @@
 package com.sysmatic2.finalbe.member.controller;
 
 import com.sysmatic2.finalbe.member.dto.*;
-import com.sysmatic2.finalbe.member.entity.FollowingStrategyEntity;
-import com.sysmatic2.finalbe.member.entity.FollowingStrategyFolderEntity;
 import com.sysmatic2.finalbe.member.repository.MemberRepository;
 import com.sysmatic2.finalbe.member.service.FollowingStrategyService;
-
+import com.sysmatic2.finalbe.strategy.service.StrategyService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -13,8 +11,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -24,7 +20,6 @@ import java.util.Map;
 
 public class FollowingStrategyController {
     private final FollowingStrategyService followingStrategyService;
-    private final MemberRepository memberRepository;
 
     //관심 전략 등록
     @PostMapping("/following-strategy")
@@ -39,7 +34,7 @@ public class FollowingStrategyController {
     }
 
     //관심 전략 목록 조회
-    @GetMapping("/follwing-strategy/list/{folderId}")
+    @GetMapping("/following-strategy/list/{folderId}")
     public ResponseEntity<Map<String,Object>> getListFollowingStrategy(@PathVariable Long folderId, FollowingStrategyRequestDto followingStrategyRequestDto, @AuthenticationPrincipal CustomUserDetails customUserDetails){
         //ArrayList<FollowingStrategyListDto> list = followingStrategyService.getListFollowingStrategy(followingStrategyRequestDto, customUserDetails);
 
@@ -51,7 +46,7 @@ public class FollowingStrategyController {
         ));
     }
     //관심 전략 목록 조회(페이징처리)
-    @GetMapping("/follwing-strategy/page/{folderId}")
+    @GetMapping("/following-strategy/page2/{folderId}")
     public ResponseEntity<Map<String,Object>> getListFollowingStrategyPage(@PathVariable Long folderId, FollowingStrategyRequestDto followingStrategyRequestDto, @AuthenticationPrincipal CustomUserDetails customUserDetails, Pageable pageable){
 
         Page<FollowingStrategyListDto> page  = followingStrategyService.getListFollowingStrategyPage(pageable,10,folderId);
@@ -65,9 +60,22 @@ public class FollowingStrategyController {
         ));
     }
 
+    //관심 전략 목록 조회(searchOptionsPayload 호출)
+    @GetMapping("/following-strategy/page/{folderId}")
+    public ResponseEntity<Map<String, Object>> getStrategiesByFolder(
+            @PathVariable Long folderId,
+            @RequestParam(defaultValue = "0") Integer page,
+            @RequestParam(defaultValue = "10") Integer pageSize) {
+
+        List<Long> strategyIds = followingStrategyService.getListFollowingStrategyList(folderId);
+        Map<String, Object> response = followingStrategyService.getStrategiesByFolder(strategyIds, page, pageSize);
+        return ResponseEntity.ok(response);
+    }
+
+
 
     //관심 전략 삭제
-    @DeleteMapping("/follwing-strategy/{followingStrategyId}")
+    @DeleteMapping("/following-strategy/{followingStrategyId}")
     public ResponseEntity<Map<String,String>> deleteFollowingStrategy(@PathVariable Long followingStrategyId, FollowingStrategyRequestDto followingStrategyRequestDto, @AuthenticationPrincipal CustomUserDetails customUserDetails){
         followingStrategyService.deleteFollowingStrategy(followingStrategyRequestDto,customUserDetails);
         return ResponseEntity.status(HttpStatus.OK).body(Map.of(
@@ -78,7 +86,7 @@ public class FollowingStrategyController {
     //관심 전략 이동
 
     //관심전략폴더ID별 관심 전략 갯수 count
-    @GetMapping("/follwing-strategy/{folderId}")
+    @GetMapping("/following-strategy/{folderId}")
     public ResponseEntity<Map<String,Object>> getCountFollowingStrategy(@PathVariable Long folderId, FollowingStrategyRequestDto followingStrategyRequestDto, @AuthenticationPrincipal CustomUserDetails customUserDetails){
         int count = followingStrategyService.countFollowingStrategy(folderId);
         return ResponseEntity.status(HttpStatus.CREATED).body(Map.of(

--- a/src/main/java/com/sysmatic2/finalbe/member/dto/FollowingStrategyFolderDto.java
+++ b/src/main/java/com/sysmatic2/finalbe/member/dto/FollowingStrategyFolderDto.java
@@ -8,7 +8,6 @@ import java.time.LocalDateTime;
 @Getter
 @Setter
 @NoArgsConstructor
-@AllArgsConstructor
 public class FollowingStrategyFolderDto {
     private Long folderId;
 
@@ -16,4 +15,20 @@ public class FollowingStrategyFolderDto {
     private String folderName;
     private LocalDateTime modifiedAt;
     private String isDefaultFolder;
+    private Long strategyCount;
+
+    public FollowingStrategyFolderDto(Long folderId, String folderName, LocalDateTime modifiedAt, String isDefaultFolder) {
+        this.folderId = folderId;
+        this.folderName = folderName;
+        this.modifiedAt = modifiedAt;
+        this.isDefaultFolder = isDefaultFolder;
+    }
+
+    public FollowingStrategyFolderDto(Long folderId, String folderName, LocalDateTime modifiedAt, String isDefaultFolder, Long strategyCount) {
+        this.folderId = folderId;
+        this.folderName = folderName;
+        this.modifiedAt = modifiedAt;
+        this.isDefaultFolder = isDefaultFolder;
+        this.strategyCount = strategyCount;
+    }
 }

--- a/src/main/java/com/sysmatic2/finalbe/member/dto/StrategyIdsDto.java
+++ b/src/main/java/com/sysmatic2/finalbe/member/dto/StrategyIdsDto.java
@@ -1,0 +1,12 @@
+package com.sysmatic2.finalbe.member.dto;
+
+import com.sysmatic2.finalbe.strategy.dto.SearchOptionsDto;
+import lombok.Getter;
+import lombok.Setter;
+import java.util.List;
+
+@Setter
+@Getter
+public class StrategyIdsDto extends SearchOptionsDto {
+    List<Long> strategyIds;
+}

--- a/src/main/java/com/sysmatic2/finalbe/member/entity/FollowingStrategyEntity.java
+++ b/src/main/java/com/sysmatic2/finalbe/member/entity/FollowingStrategyEntity.java
@@ -31,7 +31,7 @@ public class FollowingStrategyEntity extends Auditable {
     private MemberEntity member;
 
     @ManyToOne
-    @JoinColumn(name = "following_strategy_folder_id", nullable = false)
+    @JoinColumn(name = "folder_id", nullable = false)
     private FollowingStrategyFolderEntity followingStrategyFolder;
 
     @Column(name = "followed_at", nullable = false)

--- a/src/main/java/com/sysmatic2/finalbe/member/repository/FollowingStrategyFolderRepository.java
+++ b/src/main/java/com/sysmatic2/finalbe/member/repository/FollowingStrategyFolderRepository.java
@@ -15,10 +15,13 @@ public interface FollowingStrategyFolderRepository extends JpaRepository<Followi
 
     Optional<FollowingStrategyFolderEntity> findByfolderIdAndMember(Long folderId, MemberEntity member);
 
-    @Query("SELECT new com.sysmatic2.finalbe.member.dto.FollowingStrategyFolderDto(f.folderId, f.folderName, f.modifiedAt, f.isDefaultFolder) " +
+    @Query("SELECT new com.sysmatic2.finalbe.member.dto.FollowingStrategyFolderDto(f.folderId, f.folderName, f.modifiedAt, f.isDefaultFolder, COUNT(fs)) " +
             "FROM FollowingStrategyFolderEntity f " +
-            "WHERE f.member = :member")
+            "LEFT JOIN FollowingStrategyEntity fs ON fs.followingStrategyFolder.folderId = f.folderId " +
+            "WHERE f.member = :member " +
+            "GROUP BY f.folderId, f.folderName, f.modifiedAt, f.isDefaultFolder")
     List<FollowingStrategyFolderDto> findFolderDtosByMember(@Param("member") MemberEntity member);
+
 
     List<FollowingStrategyFolderEntity> findByMember(MemberEntity member);
 

--- a/src/main/java/com/sysmatic2/finalbe/member/repository/FollowingStrategyRepository.java
+++ b/src/main/java/com/sysmatic2/finalbe/member/repository/FollowingStrategyRepository.java
@@ -48,4 +48,14 @@ public interface FollowingStrategyRepository extends JpaRepository<FollowingStra
             "AND s.isApproved = 'y'")
     Page<FollowingStrategyListDto> getListFollowingStrategyPage(@Param("followingStrategyFolder") FollowingStrategyFolderEntity followingStrategyFolder, Pageable pageable);
 
+    @Query("SELECT s.strategyId " +
+            "FROM FollowingStrategyEntity f " +
+            "JOIN f.strategy s " +
+            "WHERE f.followingStrategyFolder = :followingStrategyFolder AND s.isPosted = 'y' " +
+            "AND s.isApproved = 'y'")
+    List<Long> getListFollowingStrategyList(@Param("followingStrategyFolder") FollowingStrategyFolderEntity followingStrategyFolder);
+
+
+
+
 }

--- a/src/main/java/com/sysmatic2/finalbe/strategy/repository/StrategyRepository.java
+++ b/src/main/java/com/sysmatic2/finalbe/strategy/repository/StrategyRepository.java
@@ -118,4 +118,8 @@ public interface StrategyRepository extends JpaRepository<StrategyEntity, Long>,
 
     // 전략 작성자 id로 전략 목록 전체 조회
     List<StrategyEntity> findAllByWriterId(String writerId);
+
+    @Query("SELECT s FROM StrategyEntity s WHERE s.strategyId IN :strategyIds ORDER BY s.smScore DESC")
+    Page<StrategyEntity> findByStrategyIdsOrderBySmScore(@Param("strategyIds") List<Long> strategyIds, Pageable pageable);
+
 }

--- a/src/main/java/com/sysmatic2/finalbe/strategy/repository/StrategyRepositoryCustomImpl.java
+++ b/src/main/java/com/sysmatic2/finalbe/strategy/repository/StrategyRepositoryCustomImpl.java
@@ -72,8 +72,7 @@ public class StrategyRepositoryCustomImpl implements StrategyRepositoryCustom {
                         tradingCycleId != null ? tradingCycle.tradingCycleId.eq(tradingCycleId) : null,
                         investmentAssetClassesId != null ? strategy.strategyIACEntities.any().investmentAssetClassesEntity.investmentAssetClassesId.eq(investmentAssetClassesId) : null,
                         strategy.isPosted.eq("Y"),
-                        //TODO)Y로 변경
-                        strategy.isApproved.eq("N")
+                        strategy.isApproved.eq("Y")
                 )
                 .fetchOne();
 
@@ -87,8 +86,7 @@ public class StrategyRepositoryCustomImpl implements StrategyRepositoryCustom {
                         investmentAssetClassesId != null ? strategy.strategyIACEntities.any()
                                 .investmentAssetClassesEntity.investmentAssetClassesId.eq(investmentAssetClassesId) : null,
                         strategy.isPosted.eq("Y"),
-                        //TODO)Y로 변경
-                        strategy.isApproved.eq("N")
+                        strategy.isApproved.eq("Y")
                 )
                 .orderBy(strategy.smScore.desc()) // smScore 내림차순 정렬 추가
                 .offset(pageable.getOffset())
@@ -126,9 +124,8 @@ public class StrategyRepositoryCustomImpl implements StrategyRepositoryCustom {
         // 1. is_posted = Y 필터
         strategyBuilder.and(strategyQ.isPosted.eq("Y"));
 
-        //TODO) Y로 변경하기
         // 2. is_Approved = Y 필터
-        strategyBuilder.and(strategyQ.isApproved.eq("N"));
+        strategyBuilder.and(strategyQ.isApproved.eq("Y"));
 
         // 3. 최소 운용 가능 금액 필터 - ex) 1000만원 ~ 2000만원
         if (searchOptions.getMinInvestmentAmount() != null) {


### PR DESCRIPTION
**바로 머지하지 마세요! 검토 후 머지해야합니다!**

## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [X] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [X] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 
Fix : 관심전략 기능 수정
<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1.관심 전략 api 호출 url 오타 수정

 - follwing -> following
1-1)관심전략 삭제
/following-strategy/{followingStrategyId}

1-2)회원의 폴더 ID별 관심전략 갯수(count)
/following-strategy/{folderId}

1-3)관심전략 목록 조회
/following-strategy/page/{folderId}

2.관심 전략 목록 api 수정
- 전략목록과 같은 데이터 넘겨주도록 수정

3.회원 폴더 리스트 조회시 데이터 추가
 - 폴더 별 관심전략 갯수 추가(strategyCount)

<br />

## :: 쓰이는 모듈

<br />

## :: 기타 질문 및 특이 사항

