### PR TITLE
Fix : 관심전략/ 관심전략 폴더 수정

### DIFF
--- a/src/main/java/com/sysmatic2/finalbe/exception/FolderDeletePermissionException.java
+++ b/src/main/java/com/sysmatic2/finalbe/exception/FolderDeletePermissionException.java
@@ -1,0 +1,12 @@
+package com.sysmatic2.finalbe.exception;
+
+public class FolderDeletePermissionException extends RuntimeException {
+
+    public FolderDeletePermissionException(String message) {
+        super(message);
+    }
+
+    public FolderDeletePermissionException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/sysmatic2/finalbe/exception/FolderPermissionException.java
+++ b/src/main/java/com/sysmatic2/finalbe/exception/FolderPermissionException.java
@@ -1,0 +1,7 @@
+package com.sysmatic2.finalbe.exception;
+
+public class FolderPermissionException extends RuntimeException {
+    public FolderPermissionException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/sysmatic2/finalbe/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sysmatic2/finalbe/exception/GlobalExceptionHandler.java
@@ -383,4 +383,22 @@ public class GlobalExceptionHandler {
                 "message", ex.getMessage()
         ));
     }
+
+    // 403: 폴더 삭제 권한이 없을 때
+    @ExceptionHandler(FolderDeletePermissionException.class)
+    public ResponseEntity<Object> handleFolderDeletePermissionException(FolderDeletePermissionException ex) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(Map.of(
+                "error", "FOLDER_DELETE_FORBIDDEN",
+                "message", ex.getMessage()
+        ));
+    }
+
+    // 403: 폴더 권한이 없을 때
+    @ExceptionHandler(FolderPermissionException.class)
+    public ResponseEntity<Object> handleFolderPermissionException(FolderPermissionException ex) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(Map.of(
+                "error", "FOLDER_FORBIDDEN",
+                "message", ex.getMessage()
+        ));
+    }
 }

--- a/src/main/java/com/sysmatic2/finalbe/member/controller/FollowingStrategyFolderController.java
+++ b/src/main/java/com/sysmatic2/finalbe/member/controller/FollowingStrategyFolderController.java
@@ -3,11 +3,18 @@ package com.sysmatic2.finalbe.member.controller;
 import com.sysmatic2.finalbe.member.dto.CustomUserDetails;
 import com.sysmatic2.finalbe.member.dto.FolderNameDto;
 import com.sysmatic2.finalbe.member.dto.FollowingStrategyFolderDto;
+import com.sysmatic2.finalbe.member.dto.FollowingStrategyListDto;
 import com.sysmatic2.finalbe.member.entity.MemberEntity;
+import com.sysmatic2.finalbe.member.repository.FollowingStrategyRepository;
 import com.sysmatic2.finalbe.member.repository.MemberRepository;
 import com.sysmatic2.finalbe.member.service.FollowingStrategyFolderService;
+import com.sysmatic2.finalbe.member.service.FollowingStrategyService;
 import com.sysmatic2.finalbe.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -27,6 +34,8 @@ public class FollowingStrategyFolderController {
     private final FollowingStrategyFolderService folderService;
     private final MemberService memberService;
     private final MemberRepository memberRepository;
+    private final FollowingStrategyRepository followingStrategyRepository;
+    private final FollowingStrategyService followingStrategyService;
 
     //신규 관심 전략 폴더 생성.
     @PostMapping("/following-strategy-folders")
@@ -44,23 +53,34 @@ public class FollowingStrategyFolderController {
     //특정 관심 전략 폴더 삭제.
     @DeleteMapping("/following-strategy-folders/{folderId}")
     public ResponseEntity<Map<String,Object>> deleteFolder(@PathVariable Long folderId,@AuthenticationPrincipal CustomUserDetails customUserDetails) {
-        folderService.deleteFolder(folderId);
+
+        folderService.deleteFolder(folderId,customUserDetails);
         return  ResponseEntity.status(HttpStatus.OK).body(Map.of(
                 "message", "폴더가 정상적으로 삭제되었습니다."
         ));
     }
 
-    //멤버별 관심 전략 폴더 목록 조회
-    @GetMapping("/following-strategy-folderlist")
-    public ResponseEntity<Map<String,Object>> getFolderList(@AuthenticationPrincipal CustomUserDetails customUserDetails){
-        String memberId = customUserDetails.getMemberId(); // 예: Member ID 추출
-         Optional<MemberEntity> memberEntityOptional = memberRepository.findById(memberId);
 
-        //List<FollowingStrategyFolderEntity> list =  folderService.getFolderList(memberEntityOptional.get());
-        List<FollowingStrategyFolderDto> list = folderService.getFolderList(memberEntityOptional.get());
+    //멤버별 관심 전략 폴더 목록 조회 페이징처리
+    @GetMapping("/following-strategy-folderlist")
+    public ResponseEntity<Map<String,Object>> getFolderListPage(@AuthenticationPrincipal CustomUserDetails customUserDetails,
+                                                                @RequestParam(defaultValue = "0") int page,
+                                                                @RequestParam(defaultValue = "10") int size){
+
+        MemberEntity member = customUserDetails.getMemberEntity();
+        if (member == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        //Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "modifiedAt"));
+        Pageable pageable = PageRequest.of(page, size);
+        Page<FollowingStrategyFolderDto> folderListPage = folderService.getFolderListPage(member, pageable);
+
         return ResponseEntity.status(HttpStatus.OK).body(Map.of(
-                "message","폴더 리스트 조회 성공했습니다.",
-                "data", list
+                "message","관심전략 목록이 정상적으로 조회되었습니다.",
+                "data", folderListPage.getContent(),       // 페이징된 데이터
+                "currentPage", folderListPage.getNumber(), // 현재 페이지
+                "totalItems", folderListPage.getTotalElements(), // 전체 데이터 수
+                "totalPages", folderListPage.getTotalPages() // 전체 페이지 수
         ));
     }
 

--- a/src/main/java/com/sysmatic2/finalbe/member/dto/FollowingStrategyRequestDto.java
+++ b/src/main/java/com/sysmatic2/finalbe/member/dto/FollowingStrategyRequestDto.java
@@ -8,5 +8,4 @@ import lombok.Setter;
 public class FollowingStrategyRequestDto {
     private Long folderId;
     private Long strategyId;
-    private Long followingStrategyId;
 }

--- a/src/main/java/com/sysmatic2/finalbe/member/repository/FollowingStrategyFolderRepository.java
+++ b/src/main/java/com/sysmatic2/finalbe/member/repository/FollowingStrategyFolderRepository.java
@@ -2,8 +2,11 @@ package com.sysmatic2.finalbe.member.repository;
 
 
 import com.sysmatic2.finalbe.member.dto.FollowingStrategyFolderDto;
+import com.sysmatic2.finalbe.member.dto.FollowingStrategyListDto;
 import com.sysmatic2.finalbe.member.entity.FollowingStrategyFolderEntity;
 import com.sysmatic2.finalbe.member.entity.MemberEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -26,4 +29,12 @@ public interface FollowingStrategyFolderRepository extends JpaRepository<Followi
     List<FollowingStrategyFolderEntity> findByMember(MemberEntity member);
 
     void deleteAllByMember(MemberEntity member);
+
+    @Query("SELECT new com.sysmatic2.finalbe.member.dto.FollowingStrategyFolderDto(f.folderId, f.folderName, f.modifiedAt, f.isDefaultFolder, COUNT(fs)) " +
+            "FROM FollowingStrategyFolderEntity f " +
+            "LEFT JOIN FollowingStrategyEntity fs ON fs.followingStrategyFolder.folderId = f.folderId " +
+            "WHERE f.member = :member " +
+            "GROUP BY f.folderId, f.folderName, f.modifiedAt, f.isDefaultFolder")
+    Page<FollowingStrategyFolderDto> getFolderListPage(MemberEntity member, Pageable pageable);
+
 }


### PR DESCRIPTION
**바로 머지하지 마세요! 검토 후 머지해야합니다!**

## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [X] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [X] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 
Fix : 관심전략/ 관심전략 폴더 수정
<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1.폴더 목록 조회 페이징처리 및 폴더 삭제 수정
- FollowingStrategyFolderService.java

2. 관심 전략 등록/삭제 수정
- FollowingStrategyService.java

3. 관심 전략 폴더 삭제/폴더 목록 조회 페이징처리
- FollowingStrategyFolderController.java
- FollowingStrategyFolderRepository.java

4.Dto수정
- FollowingStrategyRequestDto.java

5.예외처리
폴더 삭제 권한/ 폴더 권한
- GlobalExceptionHandler.java
- FolderDeletePermissionException.java
- FolderPermissionException.java
<br />

## :: 쓰이는 모듈
<br />

## :: 기타 질문 및 특이 사항

